### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -15,11 +15,15 @@ const ImageUploader = () => {
     >
       {previewUrl ? (
         <div className="relative w-full h-full">
-          <img
-            src={previewUrl?.startsWith('blob:') ? previewUrl : ''}
-            alt="Preview"
-            className="w-full h-full object-cover rounded-lg"
-          />
+          {previewUrl?.startsWith('blob:') ? (
+            <img
+              src={previewUrl}
+              alt="Preview"
+              className="w-full h-full object-cover rounded-lg"
+            />
+          ) : (
+            <p className="text-sm text-red-500">Invalid preview URL</p>
+          )}
           <Button 
             variant="outline" 
             size="icon"

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -16,7 +16,7 @@ const ImageUploader = () => {
       {previewUrl ? (
         <div className="relative w-full h-full">
           <img
-            src={previewUrl}
+            src={previewUrl?.startsWith('blob:') ? previewUrl : ''}
             alt="Preview"
             className="w-full h-full object-cover rounded-lg"
           />

--- a/src/components/ImageUploader.tsx
+++ b/src/components/ImageUploader.tsx
@@ -20,6 +20,10 @@ const ImageUploader = () => {
               src={previewUrl}
               alt="Preview"
               className="w-full h-full object-cover rounded-lg"
+              onError={(e) => {
+                e.currentTarget.src = '';
+                toast.error('Failed to load preview image.');
+              }}
             />
           ) : (
             <p className="text-sm text-red-500">Invalid preview URL</p>

--- a/src/context/TransformContext.tsx
+++ b/src/context/TransformContext.tsx
@@ -113,8 +113,12 @@ export const TransformProvider: React.FC<{ children: ReactNode }> = ({ children 
       }
       try {
         const url = URL.createObjectURL(file);
-        setSelectedFile(file);
-        setPreviewUrl(url);
+        if (file.type.startsWith('image/')) {
+          setSelectedFile(file);
+          setPreviewUrl(url);
+        } else {
+          toast.error('Selected file is not a valid image.');
+        }
       } catch (error) {
         toast.error('Failed to generate preview URL');
       }

--- a/src/context/TransformContext.tsx
+++ b/src/context/TransformContext.tsx
@@ -108,26 +108,29 @@ export const TransformProvider: React.FC<{ children: ReactNode }> = ({ children 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      if (file.size > 10 * 1024 * 1024) {
-        toast.error('File size must be less than 10MB');
-        return;
-      }
-      if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
-        toast.error('Only JPG, PNG, and WebP files are supported');
+      if (!validateFile(file)) {
         return;
       }
       try {
         const url = URL.createObjectURL(file);
-        if (url.startsWith('blob:')) {
-          setSelectedFile(file);
-          setPreviewUrl(url);
-        } else {
-          toast.error('Invalid file preview URL');
-        }
+        setSelectedFile(file);
+        setPreviewUrl(url);
       } catch (error) {
         toast.error('Failed to generate preview URL');
       }
     }
+  };
+
+  const validateFile = (file: File): boolean => {
+    if (file.size > 10 * 1024 * 1024) {
+      toast.error('File size must be less than 10MB');
+      return false;
+    }
+    if (!['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) {
+      toast.error('Only JPG, PNG, and WebP files are supported');
+      return false;
+    }
+    return true;
   };
 
   const handleDrop = (event: React.DragEvent) => {

--- a/src/context/TransformContext.tsx
+++ b/src/context/TransformContext.tsx
@@ -118,8 +118,12 @@ export const TransformProvider: React.FC<{ children: ReactNode }> = ({ children 
       }
       try {
         const url = URL.createObjectURL(file);
-        setSelectedFile(file);
-        setPreviewUrl(url);
+        if (url.startsWith('blob:')) {
+          setSelectedFile(file);
+          setPreviewUrl(url);
+        } else {
+          toast.error('Invalid file preview URL');
+        }
       } catch (error) {
         toast.error('Failed to generate preview URL');
       }


### PR DESCRIPTION
Potential fix for [https://github.com/jonigl/ai-home-redesign/security/code-scanning/1](https://github.com/jonigl/ai-home-redesign/security/code-scanning/1)

To address the issue, we need to ensure that the `previewUrl` used in the `src` attribute of the `<img>` tag is safe and cannot be exploited. The best approach is to validate the `previewUrl` before using it. Since `URL.createObjectURL(file)` is inherently safe, we can add a check to ensure that the `previewUrl` is indeed a blob URL. Additionally, we can use a library like `DOMPurify` to sanitize any user-generated content if necessary.

Changes to be made:
1. Add a validation function to check that `previewUrl` is a blob URL.
2. Update the `handleFileSelect` function in `src/context/TransformContext.tsx` to validate the `previewUrl` before setting it.
3. Ensure that the `previewUrl` is used safely in `src/components/ImageUploader.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
